### PR TITLE
Normalized coil weighting factors.

### DIFF
--- a/processingTools/op_addrcvrs.m
+++ b/processingTools/op_addrcvrs.m
@@ -95,7 +95,7 @@ end
 % replicate(in.dims.coils)=1;
 % ph=repmat(ph,replicate);
 % sig=repmat(sig,replicate);
-sigs=sigs/max(sigs(:));
+sigs=sigs/norm(sigs(:));
 
 ph=ones(in.sz);
 sig=ones(in.sz);


### PR DESCRIPTION
Until now, the weighting factors for the multi-channel coil combination were normalized to the maximum-intensity coil signal. Now, the coil weighting vector is normalized to unit length to prevent up- or down-scaling of signals.