### PR TITLE
Update and rename run_simPressShaped.m to run_simPressShaped_phCyc.m

### DIFF
--- a/exampleRunScripts/run_simPressShaped_phCyc.m
+++ b/exampleRunScripts/run_simPressShaped_phCyc.m
@@ -1,4 +1,8 @@
-% run_simPressShaped.m
+% 2021 EDIT: This function is now deprecated. The current version of the shaped
+% PRESS simulation is run_simPressShaped.m. The current version employs coherence
+% selection, resulting in a 4x simulation speed increase.
+
+% run_simPressShaped_phCyc.m
 % Jamie Near, McGill University 2015.
 % 
 % USAGE:
@@ -6,6 +10,7 @@
 % clicking "Run".
 % 
 % DESCRIPTION:
+%
 % This script simulates a PRESS experiment with fully shaped refocusing 
 % pulses.  Phase cycling of refocusing pulses is performed.  Furthermore, 
 % simulations are run at various locations in space to account for the 


### PR DESCRIPTION
2021 EDIT: This function is now deprecated. The current version of the shaped PRESS simulation is run_simPressShaped_coFilt.m. The current version employs coherence selection, resulting in a 4x simulation speed increase.