### PR TITLE
Update and rename sim_press_shaped.m to sim_press_shaped_phCyc.m

### DIFF
--- a/simulationTools/sim_press_shaped_phCyc.m
+++ b/simulationTools/sim_press_shaped_phCyc.m
@@ -1,8 +1,12 @@
-% sim_press_shaped.m
+% 2021 EDIT: This function is now deprecated. The current version of the 
+% shaped PRESS simulation is sim_press_shaped_coFilt.m. The current version employs
+% coherence selection rather than phase cycling to null undesired signal.
+
+% sim_press_shaped_phCyc.m
 % Robin Simpson and Jamie Near, 2014.
 % 
 % USAGE:
-% out = sim_press_shaped(n,sw,Bfield,linewidth,sys,tau1,tau2,RF,tp,dx,dy,Gx,Gy,phCyc1,phCyc2,flipAngle,centreFreq)
+% out = sim_press_shaped_phCyc(n,sw,Bfield,linewidth,sys,tau1,tau2,RF,tp,dx,dy,Gx,Gy,phCyc1,phCyc2,flipAngle,centreFreq)
 % 
 % DESCRIPTION:
 % This function simulates the PRESS experiment.  The excitation is


### PR DESCRIPTION
2021 EDIT: This function is now deprecated. The current version of the  shaped PRESS simulation is sim_press_shaped_coFilt.m. The current version employs coherence selection rather than phase cycling to null undesired signal.