### PR TITLE
FIX: Changed formula to calculate zscore

### DIFF
--- a/processingTools/op_rmbadaverages.m
+++ b/processingTools/op_rmbadaverages.m
@@ -73,8 +73,7 @@ stdev=std(metric);
 
 %Now z-transform the metric so that it is centered about zero, and they
 %have a standard deviation of 1.0.  
-zmetric=(metric-avg)./stdev;
-
+zmetric=zscore(metric);%used to be zmetric=(metric-avg)./stdev; but caused error (CMcNABB)
 
 for m=1:SS
     


### PR DESCRIPTION
zmetric=(metric-avg)./stdev  in line 76 produced an error when run in Matlab 2015b
I updated the code to use zscore:
zmetric=zscore(metric)
The code now runs with no issues