### PR TITLE
BUG: write sciNotation to jmrui txt files, set frequency in niimrs re…

### DIFF
--- a/inputOutput/io_loadspec_niimrs.m
+++ b/inputOutput/io_loadspec_niimrs.m
@@ -368,7 +368,8 @@ out.ppm = ppm;
 % Dwell time & spectral width & field strength
 out.spectralwidth = sw;
 out.dwelltime = dt;
-
+out.txfrq  = f0 * 10^6;
+out.date = '';
 
 % NIfTI-MRS-SPECIFIC FIELDS
 % Save the NIfTI header

--- a/inputOutput/io_writejmrui.m
+++ b/inputOutput/io_writejmrui.m
@@ -59,5 +59,6 @@ fprintf(fid,'\nAdditionalInfo: %s\n\n\n',addinfo);
 fprintf(fid,'Signal and FFT\n');
 fprintf(fid,'sig(real)\tsig(imag)\tfft(real)\tfft(imag)\n');
 fprintf(fid,'Signal 1 out of %i in file\n',datsets);
-fprintf(fid,'%1.8f\t%1.8f\t%1.8f\t%1.8f\n',RF');
+fprintf(fid,'%1.8E\t%1.8E\t%1.8E\t%1.8E\n',RF');
 fclose(fid);
+


### PR DESCRIPTION
This fixes two io issues.

1) `io_writejmrui.m` used 8 decimal floats to write out fid and specs data, which in some cases poorly reflects data (differences etc.) This PR switches to scientific notation. which is readable by jmrui 6.0 and is other places in the file so probably supported by other jmrui versions.

2) `io_loadspec_niimrs.m` didn't set the txfrq or the date.

Happy to add some tests if needed, but would need abit of guidance on how you would prefer I do that.

Best,
Luke